### PR TITLE
#4 - package publish tweaks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.7"
+
+services:
+  node:
+    container_name: eslint-config-node
+    image: node:20-alpine3.17
+    working_dir: /application
+    volumes:
+      - .:/application
+    restart: always

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
-  "name": "eslint-config-blumilk",
+  "name": "@blumilksoftware/eslint-config",
   "version": "1.0.0",
-  "description": "Blumilk ESLint Config",
+  "description": "Blumilk ESLint config",
   "license": "MIT",
   "keywords": [
     "typescript",
     "eslint",
     "eslint-config",
     "lint",
-    "config"
+    "config",
+    "blumilk"
   ],
   "main": "index.js",
   "author": "Blumilk",
   "repository": {
     "type": "git",
-    "url": "https://github.com/blumilksoftware/eslint-config-blumilk.git"
+    "url": "https://github.com/blumilksoftware/eslint-config-blumilk"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ ESlint config for all Blumilk projects.
 Add package to our project:
 ```shell
 npm install -D eslint typescript
-npm install git+https://github.com/blumilksoftware/eslint-config-blumilk.git
+npm install @blumilksoftware/eslint-config
 ```
 
 Create `.gitignore` file in your project's root directory:


### PR DESCRIPTION
Package should be visible in NPM registry. This PR closes #4 and adds some minor tweaks for documentation mostly.

![image](https://github.com/blumilksoftware/eslint-config-blumilk/assets/10898728/c5d0a08b-f9b1-4bea-b8a1-4ef4f74b775e)

ref: https://www.npmjs.com/package/@blumilksoftware/eslint-config