### PR TITLE
#7 - sync github releases with npm registry via gha

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,26 @@
+name: Publish Node.js Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blumilksoftware/eslint-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Blumilk ESLint config",
   "license": "MIT",
   "keywords": [
@@ -15,9 +15,10 @@
     "type": "git",
     "url": "git+https://github.com/blumilksoftware/eslint-config-blumilk.git"
   },
+  "homepage": "https://github.com/blumilksoftware/eslint-config-blumilk#readme",
   "type": "module",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "peerDependencies": {
     "eslint": ">= 9",
@@ -39,9 +40,7 @@
     "eslint.config.js",
     "typescript-config.js",
     "eslint-progress-display.js",
-    "index.js",
     "licence.md",
-    "package.json",
     "readme.md"
   ]
 }


### PR DESCRIPTION
This should close #7 

This GitHub Action requires the `NPM_TOKEN` secret to be added in the repository settings to allow publishing the package to npm.